### PR TITLE
Ignore mvnw file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/services/files-service.ts
+++ b/src/services/files-service.ts
@@ -72,7 +72,14 @@ export const createTarGzArchive = async (directoryPath: string, fileName = 'code
     const fullFileName = `**/${fileName}.tar.gz`;
 
     // a special list of files to ignore that are not in .gitignore that is may or may not be in the project
-    const additionalFilesToIgnore = ['.git/**', '.env', 'local-secure-storage.db.json', '.mappsrc', 'node_modules/**'];
+    const additionalFilesToIgnore = [
+      '.git/**',
+      '.env',
+      'local-secure-storage.db.json',
+      '.mappsrc',
+      'node_modules/**',
+      'mvnw',
+    ];
     const pathsToIgnoreFromGitIgnore = getFilesToExcludeForArchive(directoryPath);
     const pathsToIgnore = [...pathsToIgnoreFromGitIgnore, archivePath, fullFileName, ...additionalFilesToIgnore];
 


### PR DESCRIPTION
That file is an executable that being used for local development in java, we shouldn't archive it upon deployment.