### PR TITLE
Fix links to commands code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DESCRIPTION
   [@mondaydotcomorg/setup-api](https://github.com/mondaycom/monday-graphql-api/tree/main/packages/setup-api)
 ```
 
-_See code: [src/commands/api/generate.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/api/generate.ts)_
+_See code: [src/commands/api/generate.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/api/generate.ts)_
 
 ## `mapps app-features:build`
 
@@ -93,7 +93,7 @@ EXAMPLES
   $ mapps app-features:build -a APP_ID -i APP_VERSION_ID -d APP_FEATURE_ID  -t BUILD_TYPE -u CUSTOM_URL
 ```
 
-_See code: [src/commands/app-features/build.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app-features/build.ts)_
+_See code: [src/commands/app-features/build.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app-features/build.ts)_
 
 ## `mapps app-features:create`
 
@@ -120,7 +120,7 @@ EXAMPLES
   $ mapps app-features:create -a APP_ID -i APP_VERSION_ID -t APP-FEATURE-TYPE
 ```
 
-_See code: [src/commands/app-features/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app-features/create.ts)_
+_See code: [src/commands/app-features/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app-features/create.ts)_
 
 ## `mapps app-features:list`
 
@@ -145,7 +145,7 @@ EXAMPLES
   $ mapps app-features:list -a APP_ID -i APP_VERSION_ID
 ```
 
-_See code: [src/commands/app-features/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app-features/list.ts)_
+_See code: [src/commands/app-features/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app-features/list.ts)_
 
 ## `mapps app-version:builds`
 
@@ -169,7 +169,7 @@ EXAMPLES
   $ mapps app-version:builds -i APP_VERSION_ID
 ```
 
-_See code: [src/commands/app-version/builds.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app-version/builds.ts)_
+_See code: [src/commands/app-version/builds.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app-version/builds.ts)_
 
 ## `mapps app-version:list`
 
@@ -193,7 +193,7 @@ EXAMPLES
   $ mapps app-version:list
 ```
 
-_See code: [src/commands/app-version/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app-version/list.ts)_
+_See code: [src/commands/app-version/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app-version/list.ts)_
 
 ## `mapps app:create`
 
@@ -220,7 +220,7 @@ EXAMPLES
   $ mapps app:create -n NEW_APP_NAME
 ```
 
-_See code: [src/commands/app/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app/create.ts)_
+_See code: [src/commands/app/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app/create.ts)_
 
 ## `mapps app:deploy`
 
@@ -248,7 +248,7 @@ EXAMPLES
   $ mapps app:deploy
 ```
 
-_See code: [src/commands/app/deploy.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app/deploy.ts)_
+_See code: [src/commands/app/deploy.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app/deploy.ts)_
 
 ## `mapps app:list`
 
@@ -269,7 +269,7 @@ EXAMPLES
   $ mapps app:list
 ```
 
-_See code: [src/commands/app/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/app/list.ts)_
+_See code: [src/commands/app/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/app/list.ts)_
 
 ## `mapps autocomplete [SHELL]`
 
@@ -329,7 +329,7 @@ EXAMPLES
   $ mapps code:env
 ```
 
-_See code: [src/commands/code/env.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/code/env.ts)_
+_See code: [src/commands/code/env.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/code/env.ts)_
 
 ## `mapps code:logs`
 
@@ -362,7 +362,7 @@ EXAMPLES
   $ mapps code:logs -i APP_VERSION_ID -t LOGS_TYPE
 ```
 
-_See code: [src/commands/code/logs.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/code/logs.ts)_
+_See code: [src/commands/code/logs.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/code/logs.ts)_
 
 ## `mapps code:push`
 
@@ -394,7 +394,7 @@ EXAMPLES
   $ mapps code:push -a APP_ID_TO_PUSH
 ```
 
-_See code: [src/commands/code/push.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/code/push.ts)_
+_See code: [src/commands/code/push.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/code/push.ts)_
 
 ## `mapps code:status`
 
@@ -418,7 +418,7 @@ EXAMPLES
   $ mapps code:status -i APP_VERSION_ID
 ```
 
-_See code: [src/commands/code/status.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/code/status.ts)_
+_See code: [src/commands/code/status.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/code/status.ts)_
 
 ## `mapps help [COMMANDS]`
 
@@ -463,7 +463,7 @@ EXAMPLES
   $ mapps init -t SECRET_TOKEN
 ```
 
-_See code: [src/commands/init/index.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/init/index.ts)_
+_See code: [src/commands/init/index.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/init/index.ts)_
 
 ## `mapps storage:export`
 
@@ -490,7 +490,7 @@ EXAMPLES
   $ mapps storage:export -a APP_ID -c CLIENT_ACCOUNT_ID -d FILE_FULL_PATH -f FILE_FORMAT
 ```
 
-_See code: [src/commands/storage/export.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/storage/export.ts)_
+_See code: [src/commands/storage/export.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/storage/export.ts)_
 
 ## `mapps storage:search`
 
@@ -516,7 +516,7 @@ EXAMPLES
   $ mapps storage:search -a APP_ID -c CLIENT_ACCOUNT_ID -t TERM
 ```
 
-_See code: [src/commands/storage/search.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/storage/search.ts)_
+_See code: [src/commands/storage/search.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/storage/search.ts)_
 
 ## `mapps tunnel:create`
 
@@ -547,5 +547,5 @@ EXAMPLES
   $ mapps tunnel:create -p PORT_FOR_TUNNEL -a APP_ID_FOR_TUNNEL
 ```
 
-_See code: [src/commands/tunnel/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/v2.3.5/src/commands/tunnel/create.ts)_
+_See code: [src/commands/tunnel/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/master/src/commands/tunnel/create.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION
Link to commands code are invalid: 
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/5bc639b1-b156-44c3-b1d3-3033e5b2fe16" />

Updating them to point to master branch