### PR TITLE
[beta] Add new validate task to export manifest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.4.0-beta.7",
+  "version": "4.4.0-beta.8",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/commands/manifest/export.ts
+++ b/src/commands/manifest/export.ts
@@ -62,7 +62,10 @@ export default class ManifestExport extends AuthenticatedCommand {
       this.preparePrintCommand(this, flags);
 
       const tasks = new Listr<ExportCommandTasksContext>(
-        [{ title: 'Export app manifest', task: exportService.downloadManifestTask }],
+        [
+          { title: 'Validate manifest', task: exportService.validateManifestTask },
+          { title: 'Export app manifest', task: exportService.downloadManifestTask },
+        ],
         { ctx: { appVersionId, appId: appId! } },
       );
 

--- a/src/commands/manifest/export.ts
+++ b/src/commands/manifest/export.ts
@@ -63,7 +63,7 @@ export default class ManifestExport extends AuthenticatedCommand {
 
       const tasks = new Listr<ExportCommandTasksContext>(
         [
-          { title: 'Validate manifest', task: exportService.validateManifestTask },
+          { title: 'Validate app before exporting manifest', task: exportService.validateManifestTask },
           { title: 'Export app manifest', task: exportService.downloadManifestTask },
         ],
         { ctx: { appVersionId, appId: appId! } },

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -130,3 +130,7 @@ export const updateAppFromManifestUrl = (appId: AppId): string => {
 export const exportAppManifestUrl = (appId: AppId): string => {
   return `${BASE_APPS_URL}/${appId}/manifest?zipBase64=true`;
 };
+
+export const validateAppManifestUrl = (appId: AppId): string => {
+  return `${BASE_APPS_URL}/${appId}/manifest/validate`;
+};

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -131,6 +131,6 @@ export const exportAppManifestUrl = (appId: AppId): string => {
   return `${BASE_APPS_URL}/${appId}/manifest?zipBase64=true`;
 };
 
-export const validateAppManifestUrl = (appId: AppId): string => {
-  return `${BASE_APPS_URL}/${appId}/manifest/validate`;
+export const makeAppManifestExportableUrl = (appId: AppId): string => {
+  return `${BASE_APPS_URL}/${appId}/manifest/exportability`;
 };

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -3,6 +3,7 @@ import { ListrTaskWrapper } from 'listr2';
 import { exportAppManifestUrl, makeAppManifestExportableUrl } from 'consts/urls';
 import { execute } from 'services/api-service';
 import { decompressZipBufferToFiles } from 'services/files-service';
+import { HttpError } from 'src/types/errors';
 import { ExportCommandTasksContext } from 'types/commands/manifest-export';
 import { AppId, AppVersionId } from 'types/general';
 import { HttpMethodTypes } from 'types/services/api-service';
@@ -38,16 +39,22 @@ export const validateManifestTask = async (
 ) => {
   task.output = `validating manifest for app ${ctx.appId}`;
   await validateManifest(ctx.appId, ctx.appVersionId);
-  task.title = 'Manifest validation successful';
+  task.title = 'The app is valid for export';
 };
 
 export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId) => {
-  const baseUrl = makeAppManifestExportableUrl(appId);
-  const url = appsUrlBuilder(baseUrl);
+  try {
+    const baseUrl = makeAppManifestExportableUrl(appId);
+    const url = appsUrlBuilder(baseUrl);
 
-  await execute({
-    url,
-    method: HttpMethodTypes.POST,
-    query: { ...(appVersionId && { appVersionId }) },
-  });
+    await execute({
+      url,
+      method: HttpMethodTypes.POST,
+      query: { ...(appVersionId && { appVersionId }) },
+    });
+  } catch (error) {
+    if (error instanceof HttpError && error.message.includes('Cannot create slugs for live version')) {
+      throw new Error(error.message);
+    }
+  }
 };

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -1,6 +1,6 @@
 import { ListrTaskWrapper } from 'listr2';
 
-import { exportAppManifestUrl, validateAppManifestUrl } from 'consts/urls';
+import { exportAppManifestUrl, makeAppManifestExportableUrl } from 'consts/urls';
 import { execute } from 'services/api-service';
 import { decompressZipBufferToFiles } from 'services/files-service';
 import { ExportCommandTasksContext } from 'types/commands/manifest-export';
@@ -42,9 +42,8 @@ export const validateManifestTask = async (
 };
 
 export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId) => {
-  const baseUrl = validateAppManifestUrl(appId);
+  const baseUrl = makeAppManifestExportableUrl(appId);
   const url = appsUrlBuilder(baseUrl);
-  console.log('url:', url);
 
   await execute({
     url,

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -1,6 +1,6 @@
 import { ListrTaskWrapper } from 'listr2';
 
-import { exportAppManifestUrl } from 'consts/urls';
+import { exportAppManifestUrl, validateAppManifestUrl } from 'consts/urls';
 import { execute } from 'services/api-service';
 import { decompressZipBufferToFiles } from 'services/files-service';
 import { ExportCommandTasksContext } from 'types/commands/manifest-export';
@@ -30,4 +30,25 @@ export const downloadManifest = async (appId: AppId, appVersionId?: AppVersionId
   })) as any as { data: string };
 
   return response.data;
+};
+
+export const validateManifestTask = async (
+  ctx: ExportCommandTasksContext,
+  task: ListrTaskWrapper<ExportCommandTasksContext, any>,
+) => {
+  task.output = `validating manifest for app ${ctx.appId}`;
+  await validateManifest(ctx.appId, ctx.appVersionId);
+  task.title = 'Manifest validation successful';
+};
+
+export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId) => {
+  const baseUrl = validateAppManifestUrl(appId);
+  const url = appsUrlBuilder(baseUrl);
+  console.log('url:', url);
+
+  await execute({
+    url,
+    method: HttpMethodTypes.PUT,
+    query: { ...(appVersionId && { appVersionId }) },
+  });
 };

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -47,7 +47,7 @@ export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId
 
   await execute({
     url,
-    method: HttpMethodTypes.PUT,
+    method: HttpMethodTypes.POST,
     query: { ...(appVersionId && { appVersionId }) },
   });
 };


### PR DESCRIPTION
create new task to execute when export manifest. This task make http request to apps_backend and validate the app is exportable.