### PR TITLE
Feat/danieljak/support-flag-to-allow-missing-variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.4.0-beta.8",
+  "version": "4.4.0-beta.9",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/commands/manifest/import.ts
+++ b/src/commands/manifest/import.ts
@@ -13,6 +13,7 @@ const MESSAGES = {
   appId: 'App id (will create a new draft version)',
   appVersionId: 'App version id to override',
   newApp: 'Create new app',
+  allowMissingVariables: 'Allow missing variables',
 };
 
 export default class ManifestImport extends AuthenticatedCommand {
@@ -45,8 +46,8 @@ export default class ManifestImport extends AuthenticatedCommand {
       default: false,
     }),
     allowMissingVariables: Flags.boolean({
-      description: 'Allow missing variables',
-      char: 'a',
+      description: MESSAGES.allowMissingVariables,
+      char: 'm',
       aliases: ['allow-missing-variables'],
       default: false,
     }),

--- a/src/commands/manifest/import.ts
+++ b/src/commands/manifest/import.ts
@@ -44,6 +44,12 @@ export default class ManifestImport extends AuthenticatedCommand {
       aliases: ['new'],
       default: false,
     }),
+    allowMissingVariables: Flags.boolean({
+      description: 'Allow missing variables',
+      char: 'a',
+      aliases: ['allow-missing-variables'],
+      default: false,
+    }),
   });
 
   DEBUG_TAG = 'manifest_import';
@@ -63,7 +69,7 @@ export default class ManifestImport extends AuthenticatedCommand {
     try {
       const { flags } = await this.parse(ManifestImport);
       const { manifestPath: initialManifestPath } = flags;
-      const { appId: appIdAsString, appVersionId: appVersionIdAsString, newApp } = flags;
+      const { appId: appIdAsString, appVersionId: appVersionIdAsString, newApp, allowMissingVariables } = flags;
       let manifestPath = initialManifestPath;
       let appId = appIdAsString ? Number(appIdAsString) : undefined;
       let appVersionId = appVersionIdAsString ? Number(appVersionIdAsString) : undefined;
@@ -98,6 +104,7 @@ export default class ManifestImport extends AuthenticatedCommand {
         appVersionId,
         appId,
         manifestFilePath: manifestPath,
+        allowMissingVariables,
       };
       const tasks = new Listr<ImportCommandTasksContext>(
         [{ title: 'Importing app manifest', task: importService.uploadManifestTsk }],

--- a/src/services/import-manifest-service.ts
+++ b/src/services/import-manifest-service.ts
@@ -18,7 +18,7 @@ export const uploadManifestTsk = async (
   task: ListrTaskWrapper<ImportCommandTasksContext, any>,
 ) => {
   try {
-    const processedManifest = await processManifestTemplate(ctx.manifestFilePath);
+    const processedManifest = await processManifestTemplate(ctx.manifestFilePath, ctx.allowMissingVariables);
     ctx.manifestFilePath = `${ctx.manifestFilePath}.processed`;
     await saveToFile(ctx.manifestFilePath, JSON.stringify(processedManifest));
 
@@ -33,13 +33,13 @@ export const uploadManifestTsk = async (
   }
 };
 
-export const processManifestTemplate = async (manifestFilePath: string) => {
+export const processManifestTemplate = async (manifestFilePath: string, allowMissingVariables = false) => {
   try {
     const manifestJson = await loadFile(manifestFilePath);
     const parsedManifest = JSON.parse(manifestJson) as Record<string, any>;
 
     const processedManifest = processTemplate(parsedManifest, process.env, {
-      failOnMissingVariable: true,
+      failOnMissingVariable: !allowMissingVariables,
     });
     return processedManifest;
   } catch (error) {

--- a/src/types/commands/manifest-import.ts
+++ b/src/types/commands/manifest-import.ts
@@ -4,4 +4,5 @@ export type ImportCommandTasksContext = {
   appId?: AppId;
   appVersionId?: AppVersionId;
   manifestFilePath: string;
+  allowMissingVariables?: boolean;
 };


### PR DESCRIPTION
Add allowMissingVariables flag to not fail when manifest data has {{param}} syntax that is not intended to be provided by env variables