### PR TITLE
feat: Add manifest import/export commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-monday-apps-cli
-=================
+# monday-apps-cli
 
 monday.com cli tool for monday apps management.
 
 <!-- toc -->
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @mondaycom/apps-cli
 $ mapps COMMAND
@@ -22,39 +23,54 @@ USAGE
   $ mapps COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`mapps api:generate`](#mapps-apigenerate)
-* [`mapps app-features:build`](#mapps-app-featuresbuild)
-* [`mapps app-features:create`](#mapps-app-featurescreate)
-* [`mapps app-features:list`](#mapps-app-featureslist)
-* [`mapps app-version:builds`](#mapps-app-versionbuilds)
-* [`mapps app-version:list`](#mapps-app-versionlist)
-* [`mapps app:create`](#mapps-appcreate)
-* [`mapps app:deploy`](#mapps-appdeploy)
-* [`mapps app:list`](#mapps-applist)
+
+- [`mapps api:generate`](#mapps-apigenerate)
+- [`mapps app-features:build`](#mapps-app-featuresbuild)
+- [`mapps app-features:create`](#mapps-app-featurescreate)
+- [`mapps app-features:list`](#mapps-app-featureslist)
+- [`mapps app-version:builds`](#mapps-app-versionbuilds)
+- [`mapps app-version:list`](#mapps-app-versionlist)
+- [`mapps app:create`](#mapps-appcreate)
+- [`mapps app:deploy`](#mapps-appdeploy)
+- [`mapps app:list`](#mapps-applist)
+
 * [`mapps app:promote`](#mapps-apppromote)
-* [`mapps autocomplete [SHELL]`](#mapps-autocomplete-shell)
-* [`mapps code:env`](#mapps-codeenv)
-* [`mapps code:logs`](#mapps-codelogs)
-* [`mapps code:push`](#mapps-codepush)
+
+- [`mapps autocomplete [SHELL]`](#mapps-autocomplete-shell)
+- [`mapps code:env`](#mapps-codeenv)
+- [`mapps code:logs`](#mapps-codelogs)
+- [`mapps code:push`](#mapps-codepush)
+
 * [`mapps code:secret`](#mapps-codesecret)
-* [`mapps code:status`](#mapps-codestatus)
+
+- [`mapps code:status`](#mapps-codestatus)
+
 * [`mapps database:connection-string`](#mapps-databaseconnection-string)
-* [`mapps help [COMMANDS]`](#mapps-help-commands)
-* [`mapps init`](#mapps-init)
+
+- [`mapps help [COMMANDS]`](#mapps-help-commands)
+- [`mapps init`](#mapps-init)
+
 * [`mapps scheduler:create`](#mapps-schedulercreate)
 * [`mapps scheduler:delete`](#mapps-schedulerdelete)
 * [`mapps scheduler:list`](#mapps-schedulerlist)
 * [`mapps scheduler:run`](#mapps-schedulerrun)
 * [`mapps scheduler:update`](#mapps-schedulerupdate)
-* [`mapps storage:export`](#mapps-storageexport)
+
+- [`mapps manifest:export`](#mapps-manifestexport)
+- [`mapps manifest:import`](#mapps-manifestimport)
+- [`mapps storage:export`](#mapps-storageexport)
+
 * [`mapps storage:remove-data`](#mapps-storageremove-data)
-* [`mapps storage:search`](#mapps-storagesearch)
-* [`mapps tunnel:create`](#mapps-tunnelcreate)
+
+- [`mapps storage:remove-data`](#mapps-storageremove-data)
+- [`mapps storage:search`](#mapps-storagesearch)
+- [`mapps tunnel:create`](#mapps-tunnelcreate)
 
 ## `mapps api:generate`
 
@@ -66,6 +82,7 @@ USAGE
 
 DESCRIPTION
   Prepares your environment for custom queries development. run it from your root directory!
+  Creates all necessary files and scripts
   Creates all necessary files and scripts
   to start working with custom api queries and mutations.
   Read the documentation at
@@ -202,6 +219,7 @@ EXAMPLES
   $ mapps app-version:list
 ```
 
+_See code: [src/commands/app-version/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.3.2/src/commands/app-version/list.ts)_
 _See code: [src/commands/app-version/list.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.7.2/src/commands/app-version/list.ts)_
 
 ## `mapps app:create`
@@ -567,6 +585,58 @@ EXAMPLES
 
 _See code: [src/commands/init/index.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.7.2/src/commands/init/index.ts)_
 
+## `mapps manifest:export`
+
+export manifest.
+
+```
+USAGE
+  $ mapps manifest:export [--verbose] [--print-command] [-a <value>] [-v <value>]
+
+FLAGS
+  -a, --appId=<value>         App id (will export the live version)
+  -v, --appVersionId=<value>  App version id
+
+GLOBAL FLAGS
+  --print-command  Print the command that was executed (optional).
+  --verbose        Print advanced logs (optional).
+
+DESCRIPTION
+  export manifest.
+
+EXAMPLES
+  $ mapps manifest:export
+```
+
+_See code: [src/commands/manifest/export.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.3.2/src/commands/manifest/export.ts)_
+
+## `mapps manifest:import`
+
+Import manifest.
+
+```
+USAGE
+  $ mapps manifest:import [--verbose] [--print-command] [-p <value>] [-a <value>] [-v <value>] [-n]
+
+FLAGS
+  -a, --appId=<value>         App id (will create new draft version)
+  -n, --newApp                Create new app
+  -p, --manifestPath=<value>  Path of you manifest file in your machine
+  -v, --appVersionId=<value>  App version id to override
+
+GLOBAL FLAGS
+  --print-command  Print the command that was executed (optional).
+  --verbose        Print advanced logs (optional).
+
+DESCRIPTION
+  Import manifest.
+
+EXAMPLES
+  $ mapps manifest:import
+```
+
+_See code: [src/commands/manifest/import.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.3.2/src/commands/manifest/import.ts)_
+
 ## `mapps scheduler:create`
 
 Create a new scheduler job for an app
@@ -830,4 +900,5 @@ EXAMPLES
 ```
 
 _See code: [src/commands/tunnel/create.ts](https://github.com/mondaycom/monday-apps-cli/blob/v4.7.2/src/commands/tunnel/create.ts)_
+
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@oclif/core": "^3.18.1",
     "@oclif/plugin-autocomplete": "^3.0.5",
     "@oclif/plugin-help": "^6.0.12",
+    "adm-zip": "^0.5.16",
     "archiver": "^5.3.1",
     "args-parser": "^1.3.0",
     "axios": "^1.6.5",
@@ -65,6 +66,7 @@
     "fs-extra": "^11.2.0",
     "fuzzy": "^0.1.3",
     "glob": "^8.1.0",
+    "handlebars": "^4.7.8",
     "http-status-codes": "^2.2.0",
     "inquirer": "^8.2.6",
     "inquirer-autocomplete-prompt": "^2.0.0",
@@ -83,10 +85,12 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
     "@types/archiver": "^5.3.1",
     "@types/figlet": "^1.5.5",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.0.0",
+    "@types/handlebars": "^4.1.0",
     "@types/inquirer": "^8.2.10",
     "@types/inquirer-autocomplete-prompt": "^2.0.2",
     "@types/jest": "^29.5.6",

--- a/src/commands/manifest/export.ts
+++ b/src/commands/manifest/export.ts
@@ -1,0 +1,88 @@
+import { Flags } from '@oclif/core';
+import { Listr } from 'listr2';
+
+import { AuthenticatedCommand } from 'commands-base/authenticated-command';
+import { DynamicChoicesService } from 'services/dynamic-choices-service';
+import * as exportService from 'services/export-manifest-service';
+import { ExportCommandTasksContext } from 'types/commands/manifest-export';
+import logger from 'utils/logger';
+
+const MESSAGES = {
+  appId: 'App id (will export the live version)',
+  appVersionId: 'App version id',
+  path: 'Path to export your app manifest files to',
+};
+
+export default class ManifestExport extends AuthenticatedCommand {
+  static description = 'export app manifest.';
+  static withPrintCommand = false;
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> -p ./exports',
+    '<%= config.bin %> <%= command.id %> --manifestPath ./my-manifests',
+  ];
+
+  static flags = ManifestExport.serializeFlags({
+    manifestPath: Flags.string({
+      char: 'p',
+      description: MESSAGES.path,
+    }),
+    appId: Flags.string({
+      char: 'a',
+      description: MESSAGES.appId,
+    }),
+    appVersionId: Flags.integer({
+      char: 'i',
+      aliases: ['v'],
+      description: MESSAGES.appVersionId,
+    }),
+  });
+
+  DEBUG_TAG = 'manifest_export';
+
+  async getAppVersionId(appVersionId: number | undefined, appId: number | undefined): Promise<number> {
+    if (appVersionId) return appVersionId;
+
+    const latestDraftVersion = await DynamicChoicesService.chooseAppAndAppVersion(false, true, {
+      appId: Number(appId),
+      autoSelectVersion: false,
+    });
+
+    return latestDraftVersion.appVersionId;
+  }
+
+  public async run(): Promise<void> {
+    try {
+      const { flags } = await this.parse(ManifestExport);
+      const { manifestPath, appId: appIdAsString, appVersionId: appVersionIdAsString } = flags;
+
+      let appId = appIdAsString ? Number(appIdAsString) : undefined;
+      let appVersionId = appVersionIdAsString ? Number(appVersionIdAsString) : undefined;
+
+      if (appVersionId && !appId) {
+        logger.error('App id is required when app version id is provided');
+        process.exit(1);
+      }
+
+      if (!appId && !appVersionId) {
+        appId = Number(await DynamicChoicesService.chooseApp());
+        appVersionId = await this.getAppVersionId(undefined, appId);
+      }
+
+      this.preparePrintCommand(this, flags);
+
+      const tasks = new Listr<ExportCommandTasksContext>(
+        [
+          { title: 'Validate app before exporting manifest', task: exportService.validateManifestTask },
+          { title: 'Export app manifest', task: exportService.downloadManifestTask },
+        ],
+        { ctx: { appVersionId, appId: appId!, manifestPath } },
+      );
+
+      await tasks.run();
+    } catch (error) {
+      logger.debug(error, this.DEBUG_TAG);
+      process.exit(1);
+    }
+  }
+}

--- a/src/commands/manifest/import.ts
+++ b/src/commands/manifest/import.ts
@@ -1,0 +1,121 @@
+import { Flags } from '@oclif/core';
+import { Listr } from 'listr2';
+
+import { AuthenticatedCommand } from 'commands-base/authenticated-command';
+import { DynamicChoicesService } from 'services/dynamic-choices-service';
+import * as importService from 'services/import-manifest-service';
+import { PromptService } from 'services/prompt-service';
+import { ImportCommandTasksContext } from 'types/commands/manifest-import';
+import logger from 'utils/logger';
+
+const MESSAGES = {
+  path: 'Path to your app manifest file on your machine',
+  appId: 'App id (will create a new draft version)',
+  appVersionId: 'App version id to override',
+  newApp: 'Create new app',
+  allowMissingVariables: 'Allow missing variables',
+};
+
+export default class ManifestImport extends AuthenticatedCommand {
+  static description = 'Import manifest with optional template variables.';
+  static withPrintCommand = false;
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> -p ./manifest.json',
+    '<%= config.bin %> <%= command.id %> --manifestPath ./manifest.json',
+  ];
+
+  static flags = ManifestImport.serializeFlags({
+    manifestPath: Flags.string({
+      char: 'p',
+      description: MESSAGES.path,
+    }),
+    appId: Flags.string({
+      char: 'a',
+      description: MESSAGES.appId,
+    }),
+    appVersionId: Flags.integer({
+      char: 'i',
+      aliases: ['v'],
+      description: MESSAGES.appVersionId,
+    }),
+    newApp: Flags.boolean({
+      description: MESSAGES.newApp,
+      char: 'n',
+      aliases: ['new'],
+      default: false,
+    }),
+    allowMissingVariables: Flags.boolean({
+      description: MESSAGES.allowMissingVariables,
+      char: 'm',
+      aliases: ['allow-missing-variables'],
+      default: false,
+    }),
+  });
+
+  DEBUG_TAG = 'manifest_import';
+
+  async getAppVersionId(appVersionId: number | undefined, appId: number | undefined): Promise<number> {
+    if (appVersionId) return appVersionId;
+
+    const latestDraftVersion = await DynamicChoicesService.chooseAppAndAppVersion(false, false, {
+      appId: Number(appId),
+      autoSelectVersion: false,
+    });
+
+    return latestDraftVersion.appVersionId;
+  }
+
+  public async run(): Promise<void> {
+    try {
+      const { flags } = await this.parse(ManifestImport);
+      const { manifestPath: initialManifestPath } = flags;
+      const { appId: appIdAsString, appVersionId: appVersionIdAsString, newApp, allowMissingVariables } = flags;
+      let manifestPath = initialManifestPath;
+      let appId = appIdAsString ? Number(appIdAsString) : undefined;
+      let appVersionId = appVersionIdAsString ? Number(appVersionIdAsString) : undefined;
+
+      if (!manifestPath) {
+        manifestPath = await PromptService.promptFile(MESSAGES.path, ['json', 'yaml']);
+      }
+
+      const shouldCreateNewApp = await importService.shouldCreateNewApp({ appId, appVersionId, newApp });
+      if (!shouldCreateNewApp) {
+        appId = await DynamicChoicesService.chooseApp();
+      }
+
+      const shouldCreateNewAppVersion = await importService.shouldCreateNewAppVersion({
+        appId,
+        appVersionId,
+        newApp: shouldCreateNewApp,
+      });
+
+      if (!shouldCreateNewAppVersion && !shouldCreateNewApp) {
+        appVersionId = await this.getAppVersionId(appVersionId, appId);
+      }
+
+      if (appVersionId && !appId) {
+        logger.error('App id is required when app version id is provided', this.DEBUG_TAG);
+        process.exit(1);
+      }
+
+      this.preparePrintCommand(this, { appVersionId, manifestPath, appId, newApp: shouldCreateNewApp });
+
+      const ctx = {
+        appVersionId,
+        appId,
+        manifestFilePath: manifestPath,
+        allowMissingVariables,
+      };
+      const tasks = new Listr<ImportCommandTasksContext>(
+        [{ title: 'Importing app manifest', task: importService.uploadManifestTsk }],
+        { ctx },
+      );
+
+      await tasks.run();
+    } catch (error) {
+      logger.debug(error, this.DEBUG_TAG);
+      process.exit(1);
+    }
+  }
+}

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -126,3 +126,19 @@ export const appSchedulerUrl = (appId: AppId): string => {
 export const appStorageConnectionStringUrl = (appId: AppId): string => {
   return `${BASE_MONDAY_CODE_URL}/${appId}/storage/connection-string`;
 };
+
+export const createAppFromManifestUrl = (): string => {
+  return `${BASE_APPS_URL}/manifest`;
+};
+
+export const updateAppFromManifestUrl = (appId: AppId): string => {
+  return `${BASE_APPS_URL}/${appId}/manifest`;
+};
+
+export const exportAppManifestUrl = (appId: AppId): string => {
+  return `${BASE_APPS_URL}/${appId}/manifest?zipBase64=true`;
+};
+
+export const makeAppManifestExportableUrl = (appId: AppId): string => {
+  return `${BASE_APPS_URL}/${appId}/manifest/exportability`;
+};

--- a/src/services/__tests__/import-manifest-service.test.ts
+++ b/src/services/__tests__/import-manifest-service.test.ts
@@ -1,0 +1,35 @@
+import { processManifestTemplate } from 'services/import-manifest-service';
+import { loadFile } from 'utils/file-system';
+
+jest.mock('utils/file-system');
+
+describe('processManifestTemplate', () => {
+  const mockLoadFile = loadFile as jest.MockedFunction<typeof loadFile>;
+  const mockPath = 'path/to/manifest.json';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should process valid manifest with environment variables', async () => {
+    process.env.TEST_VAR = 'test-value';
+    mockLoadFile.mockResolvedValue('{"key": "{{TEST_VAR}}"}');
+
+    const result = await processManifestTemplate(mockPath);
+    expect(result).toEqual({ key: 'test-value' });
+  });
+
+  it('should throw TypeError for invalid JSON', async () => {
+    mockLoadFile.mockResolvedValue('invalid json');
+
+    await expect(processManifestTemplate(mockPath)).rejects.toThrow(TypeError);
+    await expect(processManifestTemplate(mockPath)).rejects.toThrow(/Failed to parse manifest file/);
+  });
+
+  it('should throw error for missing environment variables', async () => {
+    delete process.env.MISSING_VAR;
+    mockLoadFile.mockResolvedValue('{"key": "{{MISSING_VAR}}"}');
+
+    await expect(processManifestTemplate(mockPath)).rejects.toThrow(/Missing variable/);
+  });
+});

--- a/src/services/__tests__/mocks/invalid-manifest-mock.yml
+++ b/src/services/__tests__/mocks/invalid-manifest-mock.yml
@@ -1,15 +1,15 @@
 app:
   scopes:
-    - name: "test"
-      type: "user"
+    - name: 'test'
+      type: 'user'
       permissions:
-        - "read"
-        - "write"
+        - 'read'
+        - 'write'
   hosting:
     cdn:
       type: upload
-      path: "./build"
+      path: './build'
     server:
       type: upload
-      path: "./server"
+      path: './server'
 version: 1.0.0

--- a/src/services/__tests__/mocks/manifest-mock.yml
+++ b/src/services/__tests__/mocks/manifest-mock.yml
@@ -2,8 +2,8 @@ app:
   hosting:
     cdn:
       type: upload
-      path: "./build"
+      path: './build'
     server:
       type: upload
-      path: "./server"
+      path: './server'
 version: 1.0.0

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -99,7 +99,7 @@ export async function execute<T extends BaseResponseHttpMetaData>(
     });
 
     logger.debug({ res: response }, DEBUG_TAG);
-    const result = { ...response.data, statusCode: response?.status || 200, headers: response.headers };
+    const result = { ...response.data, statusCode: 200, headers: response.headers, data: response.data };
     const validatedResult = validateResponseIfError(result, schemaValidator);
     return (validatedResult as T) || result;
   } catch (error: any | Error | AxiosError) {

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -1,0 +1,63 @@
+import { ListrTaskWrapper } from 'listr2';
+
+import { exportAppManifestUrl, makeAppManifestExportableUrl } from 'consts/urls';
+import { execute } from 'services/api-service';
+import { decompressZipBufferToFiles } from 'services/files-service';
+import { HttpError } from 'src/types/errors';
+import { ExportCommandTasksContext } from 'types/commands/manifest-export';
+import { AppId, AppVersionId } from 'types/general';
+import { HttpMethodTypes } from 'types/services/api-service';
+import { appsUrlBuilder } from 'utils/urls-builder';
+
+export const downloadManifestTask = async (
+  ctx: ExportCommandTasksContext,
+  task: ListrTaskWrapper<ExportCommandTasksContext, any>,
+) => {
+  task.output = `downloading manifest for app ${ctx.appId}`;
+  const appManifest = await downloadManifest(ctx.appId, ctx.appVersionId);
+  const outputPath = ctx.manifestPath || `${ctx.appId}`;
+  await decompressZipBufferToFiles(Buffer.from(appManifest, 'base64'), outputPath);
+
+  const currentWorkingDirectory = process.cwd();
+  const absolutePath = outputPath.startsWith('/') ? outputPath : `${currentWorkingDirectory}/${outputPath}`;
+  task.title = `your manifest files are downloaded at ${absolutePath}`;
+};
+
+export const downloadManifest = async (appId: AppId, appVersionId?: AppVersionId) => {
+  const baseUrl = exportAppManifestUrl(appId);
+  const url = appsUrlBuilder(baseUrl);
+
+  const response = (await execute({
+    url,
+    method: HttpMethodTypes.GET,
+    query: { ...(appVersionId && { appVersionId }) },
+  })) as any as { data: string };
+
+  return response.data;
+};
+
+export const validateManifestTask = async (
+  ctx: ExportCommandTasksContext,
+  task: ListrTaskWrapper<ExportCommandTasksContext, any>,
+) => {
+  task.output = `validating manifest for app ${ctx.appId}`;
+  await validateManifest(ctx.appId, ctx.appVersionId);
+  task.title = 'The app is valid for export';
+};
+
+export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId) => {
+  try {
+    const baseUrl = makeAppManifestExportableUrl(appId);
+    const url = appsUrlBuilder(baseUrl);
+
+    await execute({
+      url,
+      method: HttpMethodTypes.POST,
+      query: { ...(appVersionId && { appVersionId }) },
+    });
+  } catch (error) {
+    if (error instanceof HttpError && error.message.includes('Cannot create slugs for live version')) {
+      throw new Error(error.message);
+    }
+  }
+};

--- a/src/services/import-manifest-service.ts
+++ b/src/services/import-manifest-service.ts
@@ -1,0 +1,144 @@
+import { ListrTaskWrapper } from 'listr2';
+
+import { createAppFromManifestUrl, updateAppFromManifestUrl } from 'consts/urls';
+import { execute } from 'services/api-service';
+import { compressFilesToZip, readZipFileAsBuffer } from 'services/files-service';
+import { PromptService } from 'services/prompt-service';
+import { ImportCommandTasksContext } from 'types/commands/manifest-import';
+import { AppId, AppVersionId } from 'types/general';
+import { HttpMethodTypes } from 'types/services/api-service';
+import { loadFile, saveToFile, unlink } from 'utils/file-system';
+import logger from 'utils/logger';
+import { processTemplate } from 'utils/templating';
+import { TIME_IN_MILLISECONDS } from 'utils/time-utils';
+import { appsUrlBuilder } from 'utils/urls-builder';
+
+export const uploadManifestTsk = async (
+  ctx: ImportCommandTasksContext,
+  task: ListrTaskWrapper<ImportCommandTasksContext, any>,
+) => {
+  try {
+    const processedManifest = await processManifestTemplate(ctx.manifestFilePath, ctx.allowMissingVariables);
+    ctx.manifestFilePath = `${ctx.manifestFilePath}.processed`;
+    await saveToFile(ctx.manifestFilePath, JSON.stringify(processedManifest));
+
+    task.output = `Zipping your manifest file`;
+    const zipFilePath = await compressFilesToZip([{ path: ctx.manifestFilePath, replaceName: 'manifest.json' }]);
+    const buffer = readZipFileAsBuffer(zipFilePath);
+    task.output = `Uploading your app manifest`;
+    await uploadZippedManifest(buffer, { appId: ctx.appId, appVersionId: ctx.appVersionId });
+    task.output = `your app manifest has been uploaded successfully`;
+  } finally {
+    await unlink(ctx.manifestFilePath);
+  }
+};
+
+export const processManifestTemplate = async (manifestFilePath: string, allowMissingVariables = false) => {
+  try {
+    const manifestJson = await loadFile(manifestFilePath);
+    const parsedManifest = JSON.parse(manifestJson) as Record<string, any>;
+
+    const processedManifest = processTemplate(parsedManifest, process.env, {
+      failOnMissingVariable: !allowMissingVariables,
+    });
+    return processedManifest;
+  } catch (error) {
+    logger.debug(error);
+
+    if (error instanceof SyntaxError) {
+      throw new TypeError(
+        `Failed to parse manifest file. Please verify that "${manifestFilePath}" contains valid JSON.`,
+      );
+    }
+
+    if (error instanceof Error && error.message.includes('Missing variable')) {
+      throw new Error(
+        `Failed to process manifest template: ${error.message}. Please ensure all required environment variables are set.`,
+      );
+    }
+
+    throw new Error(
+      `Failed to process manifest file "${manifestFilePath}". ${error instanceof Error ? error.message : ''}`,
+    );
+  }
+};
+
+export const shouldCreateNewApp = async (flags: { appId?: AppId; appVersionId?: AppVersionId; newApp?: boolean }) => {
+  if (flags.newApp || flags.appId || flags.appVersionId) {
+    return true;
+  }
+
+  const CREATE_NEW_APP = 'Create new app';
+  const IMPORT_TO_EXISTING_APP = 'Import to override an existing app';
+  const userChoice = await PromptService.promptList(
+    'How do you want to import your app',
+    [IMPORT_TO_EXISTING_APP, CREATE_NEW_APP],
+    IMPORT_TO_EXISTING_APP,
+  );
+  return userChoice === CREATE_NEW_APP;
+};
+
+export const shouldCreateNewAppVersion = async (flags: {
+  appId?: AppId;
+  appVersionId?: AppVersionId;
+  newApp?: boolean;
+}) => {
+  if (flags.appVersionId || flags.newApp) {
+    return false;
+  }
+
+  const CREATE_NEW_VERSION = 'Create a new version';
+  const OVERRIDE_EXISTING_VERSION = 'Override an existing version';
+  const userChoice = await PromptService.promptList(
+    'How do you want to import your app',
+    [OVERRIDE_EXISTING_VERSION, CREATE_NEW_VERSION],
+    OVERRIDE_EXISTING_VERSION,
+  );
+  return userChoice === CREATE_NEW_VERSION;
+};
+
+export const uploadZippedManifest = async (
+  buffer: Buffer,
+  options?: { appId?: AppId; appVersionId?: AppVersionId },
+) => {
+  const { appId, appVersionId } = options || {};
+
+  if (appId) {
+    return updateAppFromManifest(buffer, appId, appVersionId);
+  }
+
+  return createAppFromManifest(buffer);
+};
+
+const updateAppFromManifest = async (buffer: Buffer, appId: AppId, appVersionId?: AppVersionId) => {
+  const baseUrl = updateAppFromManifestUrl(appId);
+  const url = appsUrlBuilder(baseUrl);
+  const formData = new FormData();
+  formData.append('zipfile', new Blob([buffer]));
+
+  const response = await execute({
+    url,
+    headers: { Accept: 'application/json', 'Content-Type': 'multipart/form-data' },
+    method: HttpMethodTypes.PUT,
+    body: formData,
+    query: { ...(appVersionId && { appVersionId }) },
+    timeout: TIME_IN_MILLISECONDS.SECOND * 30,
+  });
+  return response;
+};
+
+const createAppFromManifest = async (buffer: Buffer) => {
+  const baseUrl = createAppFromManifestUrl();
+  const url = appsUrlBuilder(baseUrl);
+  const formData = new FormData();
+  formData.append('zipfile', new Blob([buffer]));
+
+  const response = await execute({
+    url,
+    headers: { Accept: 'application/json', 'Content-Type': 'multipart/form-data' },
+    method: HttpMethodTypes.POST,
+    body: formData,
+    timeout: TIME_IN_MILLISECONDS.SECOND * 30,
+  });
+  return response;
+};

--- a/src/types/commands/manifest-export.ts
+++ b/src/types/commands/manifest-export.ts
@@ -1,0 +1,7 @@
+import type { AppId, AppVersionId } from 'types/general';
+
+export type ExportCommandTasksContext = {
+  appId: AppId;
+  appVersionId?: AppVersionId;
+  manifestPath?: string;
+};

--- a/src/types/commands/manifest-import.ts
+++ b/src/types/commands/manifest-import.ts
@@ -1,0 +1,8 @@
+import type { AppId, AppVersionId } from 'types/general';
+
+export type ImportCommandTasksContext = {
+  appId?: AppId;
+  appVersionId?: AppVersionId;
+  manifestFilePath: string;
+  allowMissingVariables?: boolean;
+};

--- a/src/utils/__tests__/templating.test.ts
+++ b/src/utils/__tests__/templating.test.ts
@@ -1,0 +1,69 @@
+import { processTemplate } from 'utils/templating';
+
+describe('processTemplate', () => {
+  it('should replace placeholders with provided variables', () => {
+    const jsonContent = { name: '{{APP_NAME}}', version: '1.0.0' };
+    const vars = { APP_NAME: 'MyCoolApp' };
+
+    const result = processTemplate(jsonContent, vars);
+
+    expect(result).toEqual({ name: 'MyCoolApp', version: '1.0.0' });
+  });
+
+  it('should leave placeholders unchanged if variable is missing and failOnMissingVariable is false', () => {
+    const jsonContent = { name: '{{APP_NAME}}', version: '{{VERSION}}' };
+    const vars = { APP_NAME: 'MyCoolApp' };
+
+    const result = processTemplate(jsonContent, vars, { failOnMissingVariable: false });
+
+    expect(result).toEqual({ name: 'MyCoolApp', version: '{{VERSION}}' });
+  });
+
+  it('should throw an error if failOnMissingVariable is true and a variable is missing', () => {
+    const jsonContent = { name: '{{APP_NAME}}', version: '{{VERSION}}' };
+    const vars = { APP_NAME: 'MyCoolApp' };
+
+    expect(() => processTemplate(jsonContent, vars, { failOnMissingVariable: true })).toThrow(
+      'Missing variable: VERSION',
+    );
+  });
+
+  it('should process deeply nested JSON objects', () => {
+    const jsonContent = {
+      app: {
+        name: '{{APP_NAME}}',
+        metadata: { version: '{{VERSION}}' },
+      },
+    };
+    const vars = { APP_NAME: 'NestedApp', VERSION: '2.0.0' };
+
+    const result = processTemplate(jsonContent, vars);
+
+    expect(result).toEqual({
+      app: {
+        name: 'NestedApp',
+        metadata: { version: '2.0.0' },
+      },
+    });
+  });
+
+  it('should process arrays with placeholders', () => {
+    const jsonContent = {
+      names: ['{{FIRST_NAME}}', '{{LAST_NAME}}'],
+    };
+    const vars = { FIRST_NAME: 'John', LAST_NAME: 'Doe' };
+
+    const result = processTemplate(jsonContent, vars);
+
+    expect(result).toEqual({
+      names: ['John', 'Doe'],
+    });
+  });
+
+  it('should throw an error if JSON parsing fails after template processing', () => {
+    const jsonContent = { value: '{{INVALID_JSON}}' };
+    const vars = { INVALID_JSON: '{"unclosed": "object"' };
+
+    expect(() => processTemplate(jsonContent, vars)).toThrow(/Expected ',' or '}' after property value/);
+  });
+});

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -16,3 +16,16 @@ export const saveToFile = async (filePath: string, content: string) => {
     throw new FSError(`Failed to save file, please check if this file path "${filePath}" is correct.`);
   }
 };
+
+export const loadFile = (filePath: string) => {
+  try {
+    return fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    logger.debug(error);
+    throw new FSError(`Failed to load file, please check if this file path "${filePath}" is correct.`);
+  }
+};
+
+export const unlink = async (path: string): Promise<void> => {
+  await fs.unlink(path);
+};

--- a/src/utils/templating.ts
+++ b/src/utils/templating.ts
@@ -1,0 +1,32 @@
+import Handlebars from 'handlebars';
+
+/**
+ * Process a JSON template file with Handlebars.
+ * @param jsonContent - The JSON content to process.
+ * @param vars - The variables to substitute in the template.
+ * @param options - Additional options.
+ * @returns The processed JSON object.
+ */
+export function processTemplate(
+  jsonContent: Record<string, any>,
+  vars: Record<string, unknown>,
+  options: { failOnMissingVariable?: boolean } = {},
+): Record<string, any> {
+  const { failOnMissingVariable = false } = options;
+  const jsonString = JSON.stringify(jsonContent);
+
+  Handlebars.registerHelper('getVar', (key: string) => {
+    if (failOnMissingVariable && !(key in vars)) {
+      throw new Error(`Missing variable: ${key}`);
+    }
+
+    return vars[key] ?? `{{${key}}}`;
+  });
+
+  const transformedTemplate = jsonString.replaceAll(/{{\s*([\w.-]+)\s*}}/g, (_, varName) => `{{getVar "${varName}"}}`);
+
+  const template = Handlebars.compile(transformedTemplate, { noEscape: true });
+  const output = template(vars);
+
+  return JSON.parse(output) as Record<string, any>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,6 +2504,13 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
+"@types/adm-zip@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz#eec10b6f717d3948beb64aca0abebc4b344ac7e9"
+  integrity sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/archiver@^5.3.1":
   version "5.3.4"
   resolved "https://registry.npmjs.org/@types/archiver/-/archiver-5.3.4.tgz"
@@ -2593,6 +2600,13 @@
   integrity sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==
   dependencies:
     "@types/node" "*"
+
+"@types/handlebars@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
+  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
+  dependencies:
+    handlebars "*"
 
 "@types/http-cache-semantics@*", "@types/http-cache-semantics@^4.0.2":
   version "4.0.3"
@@ -2950,6 +2964,11 @@ acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+
+adm-zip@^0.5.16:
+  version "0.5.16"
+  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
+  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -5450,6 +5469,18 @@ grouped-queue@^2.0.0:
   resolved "https://registry.npmjs.org/grouped-queue/-/grouped-queue-2.0.0.tgz"
   integrity sha512-/PiFUa7WIsl48dUeCvhIHnwNmAAzlI/eHoJl0vu3nsFA366JleY7Ff8EVTplZu5kO0MIdZjKTTnzItL61ahbnw==
 
+handlebars@*, handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz"
@@ -7241,6 +7272,11 @@ negotiator@^0.6.2, negotiator@^0.6.3:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -8884,16 +8920,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8952,14 +8979,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9386,6 +9406,11 @@ typescript@^5.3.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz"
@@ -9685,7 +9710,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9698,15 +9723,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Add manifest import command with custom path and missing variables support
- Add manifest export command with custom path and validation
- Add validation functionality for manifest export
- Add templating utilities for manifest processing
- Add comprehensive tests for import functionality
- Update API service and file utilities
- Update package version and documentation

This PR mainly merge the beta version of the manifest with the current master changes.